### PR TITLE
Fixed black/pylint conflict and added black check to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,37 @@ env:
     - LANG=en_US.UTF-8
     - LC_ALL=en_US.UTF-8
     - secure: 2c0250fb-dfb1-45c9-abaf-cd3d874326c5
+
 # install mdl for checking Markdown
 before_install:
   - gem install mdl
+
 notifications:
   email: never
 
+# command to install dependencies
 install:
   - pip install --upgrade pip
   - pip install --upgrade pipenv
   - pipenv install --dev
 
+# perform testing:
+# --> run the test suite with pytest
+# --> lint the functions with flake8
+# --> lint the test suites with flake8
+# --> lint the functions with pylint
+# --> lint the test suites with pylint
+# --> lint the README documentation with mdl
 script:
   - pipenv run pytest tests --cov-config pytest.cov --cov
+  - pipenv run black *.py --check
+  - pipenv run black tests --check
   - pipenv run flake8 tests*
-  - pipenv run flake8 gatorgrouper*
-  - pipenv run pylint *.py
+  - pipenv run flake8 *.py
   - pipenv run pylint tests
+  - pipenv run pylint *.py
   - mdl README.md
 
+# report coverage information to CodeCov
 after_success:
   - pipenv run codecov

--- a/gatorgrouper.py
+++ b/gatorgrouper.py
@@ -48,16 +48,17 @@ if __name__ == "__main__":
     logging.info("\n %s", create_escaped_string_from_list(SHUFFLED_STUDENT_IDENTIFIERS))
 
     # generate the groups and display them
+    # pylint: disable=bad-continuation
     if (
-            GG_ARGUMENTS.grouping_method == "rrobin"
-            and GG_ARGUMENTS.num_group is DEFAULT_NUMGRP
+        GG_ARGUMENTS.grouping_method == "rrobin"
+        and GG_ARGUMENTS.num_group is DEFAULT_NUMGRP
     ):
         GROUPED_STUDENT_IDENTIFIERS = group_rrobin_group_size(
             SHUFFLED_STUDENT_IDENTIFIERS, GG_ARGUMENTS.group_size
         )
     elif (
-            GG_ARGUMENTS.grouping_method == "rrobin"
-            and GG_ARGUMENTS.num_group is not DEFAULT_NUMGRP
+        GG_ARGUMENTS.grouping_method == "rrobin"
+        and GG_ARGUMENTS.num_group is not DEFAULT_NUMGRP
     ):
         GROUPED_STUDENT_IDENTIFIERS = group_rrobin_num_group(
             SHUFFLED_STUDENT_IDENTIFIERS, GG_ARGUMENTS.num_group

--- a/parse_arguments.py
+++ b/parse_arguments.py
@@ -84,21 +84,22 @@ def parse_arguments(args):
         level=gg_arguments_finished.logging_level,
     )
 
+    # pylint: disable=bad-continuation
     if (
-            check_valid_group_size(
-                gg_arguments_finished.group_size,
-                read_student_file(gg_arguments_finished.students_file),
-            )
-            is False
+        check_valid_group_size(
+            gg_arguments_finished.group_size,
+            read_student_file(gg_arguments_finished.students_file),
+        )
+        is False
     ):
         quit()
 
     if (
-            check_valid_num_group(
-                gg_arguments_finished.num_group,
-                read_student_file(gg_arguments_finished.students_file),
-            )
-            is False
+        check_valid_num_group(
+            gg_arguments_finished.num_group,
+            read_student_file(gg_arguments_finished.students_file),
+        )
+        is False
     ):
         quit()
 


### PR DESCRIPTION
`black` caused formatting changes that caused `bad-continuation` `pylint` issues in `gatorgrouper.py` and `parse_arguments.py` . I simple suppressed/disable issues in the aforementioned python modules.

I also added a check in `Travis` to see if black was run on the files and modules.