### PR TITLE
Feature/multiple python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ matrix:
       language: generic
       python: "3.6"
       osx_image: xcode10.1
+    - os: windows
+      language: sh
+      python: "3.7"
+      before_install:
+        - choco install python3
+        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - python -m pip install --upgrade pip wheel
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,6 @@ python:
   - "3.5"
   - "3.4"
 
-matrix:
-  include:
-    - os: osx
-      language: generic
-      python: "3.6"
-      osx_image: xcode10.1
-    - os: windows
-      language: sh
-      python: "3.7"
-      before_install:
-        - choco install python3
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-        - python -m pip install --upgrade pip wheel
-
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
-python:
-  language: python
+language: python
+  python:
   - "3.7"
   - "3.6"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.7"
   - "3.6"
   - "3.5"
+  - "3.4"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   include:
     - os: osx
       language: generic
+      python: "3.6"
       osx_image: xcode10.1
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: xenial
 language: python
   python:
-  - "3.7"
-  - "3.6"
-  - "3.5"
-  - "3.4"
+    - "3.7"
+    - "3.6"
+    - "3.5"
+    - "3.4"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: xenial
 language: python
-  python:
-    - "3.7"
-    - "3.6"
-    - "3.5"
-    - "3.4"
+python:
+  - "3.7"
+  - "3.6"
+  - "3.5"
+  - "3.4"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ python:
   - "3.5"
   - "3.4"
 
+matrix:
+  include:
+    - os: osx
+      language: generic
+      osx_image: xcode10.1
+
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 dist: xenial
-language: python
-python: 3.7
-
+python:
+  language: python
+  - "3.7"
+  - "3.6"
+  - "3.5"
 
 cache:
   directories:


### PR DESCRIPTION
## Description

Completed issue #105 and added multiple python versions to Travis to test on. This was done without the use of `tox` nor `pyenv`. Using `tox` has been deemed unnecessary for now.

## Versions Used

Python versions used: `3.4, 3.5, 3.6, 3.7`