### PR TITLE
Fixed what failed test_display_student_groups

### DIFF
--- a/display.py
+++ b/display.py
@@ -16,7 +16,7 @@ def display_student_groups(student_groups):
             print("\033[0m" + student[0])  # converts the students back to original font
         print()
         group_counter = group_counter + 1
-    logging.info("Found %d students", place_counter)
+    logging.info("Found " + str(place_counter) + " students")
 
 
 def display_welcome_message():


### PR DESCRIPTION
```
――――――――――――――――――――――――――――――――――――――――――――― test_display_student_groups ――――――――――――――――――――――――――――――――――――――――――――――

capsys = <_pytest.capture.CaptureFixture object at 0x7f16089ec410>

    def test_display_student_groups(capsys):
        """Checking the display of the student_groups"""
        student_groups = [
            ["gkapfham3", "gkapfham0"],
            ["gkapfham1", "gkapfham4"],
            ["gkapfham5", "gkapfham7", "gkapfham6"],
        ]
        display.display_student_groups(student_groups)
        out, _ = capsys.readouterr()
>       assert out.startswith("\033[0;32m" + "\033[1m" + "\033[4m" + "Group 1")
E       assert False
E        +  where False = <built-in method startswith of unicode object at 0x7f1608a7f270>(((('\x1b[0;32m' + '\x1b[1m') + '\x1b[4m') + 'Group 1'))
E        +    where <built-in method startswith of unicode object at 0x7f1608a7f270> = "('\x1b[0;32m\x1b[1m\x1b[4mGroup', 1)\ng\ng\n()\n('\x1b[0;32m\x1b[1m\x1b[4mGroup', 2)\ng\ng\n()\n('\x1b[0;32m\x1b[1m\x1b[4mGroup', 3)\ng\ng\ng\n()\n".startswith

tests/test_display.py:14: AssertionError

 tests/test_display.py::test_display_student_groups ⨯                                                     57% █████▋
```